### PR TITLE
dependencies: Remove need for gron

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ In the case of shells, this should allow you to easily spawn a new shell in the 
 
 ## Dependencies
 
-You will need `jq` and `gron` and you will also need to be using `swaywm`.
+You will need `jq` and you will also need to be using `swaywm`.
 
 ```sh
 # Install jq on Arch
 pacman -S jq
-# gron is available in the AUR
-yay -S gron
 ```
 
 ## Usage

--- a/swaycwd
+++ b/swaycwd
@@ -6,9 +6,7 @@
 # Grab the window/display tree
 TREE=$(swaymsg -t get_tree)
 # Find the focused node
-TREE_PATH=$(echo "$TREE" | gron | grep "focused = true" | sed 's/.focused.*$/.pid/g;s/^json//g')
-# Find the PID of the process
-PID=$(echo "$TREE" | jq "$TREE_PATH")
+PID=$(echo "$TREE" | jq -r '.. | select(.focused?) | .pid')
 
 # how far down does the rabbit hole go? D:
 while pgrep -P "$PID" >/dev/null; do


### PR DESCRIPTION
jq is perfectly able to handle the job of filtering through a json file, and is quite efficient in doing so too.

As we already have the jq dependency, we don't need to make use of gron anymore.